### PR TITLE
Fix bug for jQuery versions 1.7.2 - 1.8.3

### DIFF
--- a/jquery.sonar.js
+++ b/jquery.sonar.js
@@ -284,7 +284,7 @@ var body = doc.body,
                 // console.log("triggered:" + elem.id);
                 // Trigger the onscreen or offscreen event depending
                 // on the desired event.
-                $(elem).trigger( screenEvent );
+                $(elem).triggerHandler( screenEvent );
 
                 options.tr = 1;
 
@@ -335,7 +335,7 @@ var body = doc.body,
       // Trigger the onscreen event at the next possible cycle.
       // Artz: Ask the jQuery team why I needed to do this.
       setTimeout(function(){
-        $(elem).trigger( screenEvent === offScreenEvent ? offScreenEvent : onScreenEvent );
+        $(elem).triggerHandler( screenEvent === offScreenEvent ? offScreenEvent : onScreenEvent );
       }, 0);
       triggered = 1;
     // Otherwise, add it to the polling queue.


### PR DESCRIPTION
I haven't yet figured out exactly WHY Sonar breaks in jQuery versions
1.7.2 - 1.8.3, but you can see it in action through this Fiddle:

http://jsfiddle.net/FZXpt/1/

Changing both of the $.trigger methods to use $.triggerHandler fixes the
issue for all versions of jQuery currently on jsFiddle (1.6.4 - 2.0.2).

I haven't updated the minified version of the file, since you might have
a preferred minifier.
